### PR TITLE
Added specific Curriculum Goals from 2015 CUPM to Curricular Guidelines

### DIFF
--- a/CURRICULAR_GUIDELINES.md
+++ b/CURRICULAR_GUIDELINES.md
@@ -9,3 +9,45 @@ The 2015 CUPM Curriculum Guide is prepared by the MAA’s Committee on the Under
 ### Mathematical Association of America
 
 _"The Mathematical Association of America is the world’s largest community of mathematicians, students, and enthusiasts. We further the understanding of our world through mathematics because mathematics drives society and shapes our lives. The mission of the MAA is to advance the understanding of mathematics and its impact on our world. Our members include university, college, and high school teachers; graduate and undergraduate students; pure and applied mathematicians; computer scientists; statisticians; STEM professionals, and many others in academia, government, business, and industry. We welcome all who are interested in the mathematical sciences."_
+
+## Curriculum Goals
+
+The 2015 CUPM Curriculum Guide states:
+
+> A successful [mathematics] major offers a program of courses to gradually and intentionally lead students from basic to advanced levels of critical and analytical thinking, while encouraging creativity and excitement about mathematics.
+
+These cognitive and content goals are presented in the CUPM for the purpose of guiding curriculum design. OSSU has adopted these goals for the Mathematics curriculum:
+
+### Cognitive Goals
+
+1. Students should develop effective thinking and communication skills.
+
+2. Students should learn to link applications and theory.
+
+3. Students should learn to use technological tools.
+
+4. Students should develop mathematical independence and experience
+open-ended inquiry.
+
+### Content Goals
+
+1. Mathematical sciences major programs should include concepts and methods from calculus and linear algebra. 
+
+2. Students majoring in the mathematical sciences should learn to read, understand, analyze, and produce proofs at increasing depth as they progress through a major.
+
+3. Mathematical sciences major programs should include concepts and methods from data analysis, computing, and mathematical modeling.
+
+4. Mathematical sciences major programs should present key ideas and concepts from a variety of perspectives to demonstrate the breadth of mathematics. 
+
+5. Students majoring in the mathematical sciences should experience mathematics from the perspective of another discipline. 
+
+6. Mathematical sciences major programs should present key ideas from
+complementary points of view: continuous and discrete; algebraic and geometric; deterministic and stochastic; exact and approximate.
+
+7. Mathematical sciences major programs should require the study of at least
+one mathematical area in depth, with a sequence of upper-level courses.
+
+8. Students majoring in the mathematical sciences should work, independently or in a small group, on a substantial mathematical project that involves techniques and concepts beyond the typical content of a single course.
+
+9. Mathematical sciences major programs should offer their students an orientation to careers in mathematics.
+


### PR DESCRIPTION
**Issues:** 

1. The OSSU Math curriculum references the 2015 CUPM. While being an excellent design document, it is not immediately clear what aspects of CUPM we are referencing. 

2. The OSSU Math curriculum does not currently have a clean and clear set of high-level guiding goals for its mathematics curriculum. Without guiding goals, a cohesive curriculum will be much harder to obtain.

**Solution**: This PR clarifies that OSSU Math is adopting the *curriculum goals* outlined in the 2015 CUPM's *Overview of Majors in the Mathematical Sciences*. This is not a list of courses, but a guiding philosophy of what students pursuing a mathematics degree should learn, develop, and be exposed to while studying the major.

Once this guiding principle is established, OSSU can weigh proposed courses against these cognitive goals and content goals.

The full text of these goals with additional explanatory material is available in the 2015 CUPM.