### PR TITLE
Update links to Pre-College Math

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -19,19 +19,8 @@ Alternatively, you could [contribute](#CONTRIBUTING.md) an answer yourself.
 ## Questions
 
 ### How can I review the math prerequisites?
-Many OSSU students choose to review math topics that they have not studied recently.
-OSSU recommends students use Khan Academy for such a review.
-Below are links to topic assessments.
-After taking an assessment, you should have a clear idea what topics to study, and resources on Khan Academy to use.
 
-- [Arithmetic](https://www.khanacademy.org/math/arithmetic#arithmetic-subject-challenge)
-- [Basic Geometry](https://www.khanacademy.org/math/basic-geo#basic-geo-subject-challenge)
-- [Pre-algebra](https://www.khanacademy.org/math/pre-algebra#pre-algebra-subject-challenge)
-- [High School Math 1](https://www.khanacademy.org/math/math1#math1-subject-challenge)
-- [High School Math 2](https://www.khanacademy.org/math/math2#math2-subject-challenge)
-- [High School Math 3](https://www.khanacademy.org/math/math3#math3-subject-challenge)
-
-(Math 1, 2, 3 covers all of algebra, pre-calculus, high school geometry, trig, stats. It interleaves the order of these topics.)
+See our [Pre-College Math](https://ossu.dev/precollege-math) curriculum for a list of resources to use for reviewing the math prerequisites.
 
 ### In what order should I take the courses?
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Calculus is the study of change (differential calculus) and accumulation of quan
 
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
-[Calculus 1A: Differentiation](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+18.01.1x+2T2019/about) | 13 weeks | 6-10 hours/week | [high school math](FAQ.md#how-can-i-review-the-math-prerequisites)
+[Calculus 1A: Differentiation](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+18.01.1x+2T2019/about) | 13 weeks | 6-10 hours/week | [high school math](https://ossu.dev/precollege-math)
 [Calculus 1B: Integration](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+18.01.2x+3T2019/about) | 13 weeks | 5-10 hours/week | Calculus 1A 
 [Calculus 1C: Coordinate Systems & Infinite Series](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+18.01.3x+1T2020/about) | 6 weeks | 5-10 hours/week | Calculus 1B
 [Multivariable Calculus](https://ocw.mit.edu/courses/mathematics/18-02sc-multivariable-calculus-fall-2010/) | 12 weeks | 6 hours/week | Calculus 1C 
@@ -157,7 +157,7 @@ Linear algebra is the mathematics of spatial relationships that deals with the m
 
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
-[Essence of Linear Algebra](https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab) | - | - | [high school math](FAQ.md#how-can-i-review-the-math-prerequisites)
+[Essence of Linear Algebra](https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab) | - | - | [high school math](https://ossu.dev/precollege-math)
 [Linear Algebra](https://ocw.mit.edu/courses/mathematics/18-06sc-linear-algebra-fall-2011/) | 14 weeks | 12 hours/week | Essence of Linear Algebra
 
 ### Probability & Statistics
@@ -194,7 +194,7 @@ Abstract algebra (occasionally called modern algebra) is the study of algebraic 
 
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
-[Introduction to Abstract Group theory](https://nptel.ac.in/courses/111106113) | 8 weeks | 8-10 hours/week | [high school math](FAQ.md#how-can-i-review-the-math-prerequisites) 
+[Introduction to Abstract Group theory](https://nptel.ac.in/courses/111106113) | 8 weeks | 8-10 hours/week | [high school math](https://ossu.dev/precollege-math) 
 [Introduction to Rings and Fields](https://nptel.ac.in/courses/111106131) | 8 weeks | 8-10 hours/week | Introduction to Abstract Group Theory
 
 
@@ -215,7 +215,7 @@ Courses | Duration | Effort | Prerequisites
 ### Geometry and Topology
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
-[Topology Without Tears](https://www.topologywithouttears.net) | 15 weeks | 14 hours/week | [high school math](FAQ.md#how-can-i-review-the-math-prerequisites), Set Theory, Knowledge of axiomatic branch of mathematics such as [Introduction to Abstract Algebra](#introduction-to-abstract-algebra) 
+[Topology Without Tears](https://www.topologywithouttears.net) | 15 weeks | 14 hours/week | [high school math](https://ossu.dev/precollege-math), Set Theory, Knowledge of axiomatic branch of mathematics such as [Introduction to Abstract Algebra](#introduction-to-abstract-algebra) 
 [Euclidean plane and its relatives](https://arxiv.org/pdf/1302.1630v19.pdf) | 14 weeks | 4-6 hours/week | Elementary Set Theory, Calculus 1C, Linear Algebra
 [Geometry with an Introduction to Cosmic Topology](https://mphitchman.com) | 14 weeks | 14 hours/week | Multivariable Calculus
 [Differential Geometry](https://ocw.mit.edu/courses/mathematics/18-950-differential-geometry-fall-2008/) [(Supplementary Video Lectures)](https://www.youtube.com/playlist?list=PLIljB45xT85DWUiFYYGqJVtfnkUFWkKtP)  | 10 weeks | 6-8 hours/week | Multivariable Calculus, Introduction To Analysis and Linear Algebra


### PR DESCRIPTION
This removes mention of the previous recommendations and links directly to <https://ossu.dev/precollege-math>.